### PR TITLE
Show power chains 

### DIFF
--- a/pages/powers/_id.vue
+++ b/pages/powers/_id.vue
@@ -169,7 +169,8 @@
                   </span>
 
                   <!-- Chained Powers -->
-                  <div id="chained-powers" class="w-full">
+                  <div id="chained-powers" class="w-full"
+                       v-if="(powerData.chain.next && powerData.chain.next.length > 0) || (powerData.chain.prev && powerData.chain.prev.length > 0)">
                     <h2 class="text-sm font-bold text-gray-700 tracking-wider mb-1">
                       Chained Powers
                     </h2>

--- a/pages/powers/_id.vue
+++ b/pages/powers/_id.vue
@@ -167,6 +167,353 @@
                   >
                     {{ powerData.name }} {{ powerData.description }}
                   </span>
+
+                  <!-- Chained Powers -->
+                  <div id="chained-powers" class="w-full">
+                    <h2 class="text-sm font-bold text-gray-700 tracking-wider mb-1">
+                      Chained Powers
+                    </h2>
+                    <div id="next-powers"
+                         v-if="powerData.chain.next && powerData.chain.next.length > 0"
+                         class="w-full ml-4 border-gray-500 border-solid border-l-4 pl-2 mb-2">
+                      <h3 class="text-xs font-medium uppercase text-gray-600 mb-1 tracking-widest">
+                        Next Powers
+                      </h3>
+                      <div v-for="power of powerData.chain.next">
+                        <!-- Power Details Card TODO: Make this a re-usable component -->
+                        <div id="power-details" class="flex my-2">
+                          <div class="flex-none">
+                            <img
+                              :src="`https://cdn.malekai.org/power/${power.id}.png`"
+                              class="w-10 mr-1"
+                            />
+                          </div>
+
+                          <div class="">
+                            <nuxt-link :to="`/powers/${power.id}`">
+                            <span
+                              class="block text-gray-700 font-medium text-xs uppercase tracking-wide mr-2"
+                            >{{ power.name }}</span
+                            >
+                              <span class="block font-normal text-xs italic">{{
+                                  power.shortDescription
+                                }}</span>
+                            <div class="mt-2 mr-3 align-text-top block clear-both">
+                              <span class="block flex flex-wrap justify-start mb-1 ">
+                                <span
+                                  v-if="power.stats.cast_time"
+                                  class="italic text-xs mt-1 mr-3 md:mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-casttime.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Cast Time"
+                                  />
+                                  {{ power.stats.cast_time }}
+                                </span>
+                                <span
+                                  v-if="power.stats.cooldown"
+                                  class="italic text-xs mt-1 mr-3 md:mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-cooldown.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Cooldown"
+                                  />
+                                  {{ power.stats.cooldown }}
+                                </span>
+
+                                <span
+                                  v-if="power.stats.duration"
+                                  class="italic text-xs mt-1 mr-3 md:mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-duration.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Duration"
+                                  />
+                                  {{ power.stats.duration }}
+                                </span>
+                                <span
+                                  v-if="power.stats.target"
+                                  class="italic text-xs mt-1 mr-3 md: mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-targetingtype.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Targeting Type"
+                                  />
+                                  {{ power.stats.target }}
+                                </span>
+                                <span
+                                  v-if="power.stats.max_targets"
+                                  class="italic text-xs mt-1 mr-3 md:mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-maxtargets.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Max Targets"
+                                  />
+                                  {{ power.stats.max_targets }}
+                                </span>
+                                <span
+                                  v-if="power.stats.range"
+                                  class="italic text-xs mt-1 mr-3 md: mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-range.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Range"
+                                  />
+                                  {{ power.stats.range }}
+                                </span>
+                                <span
+                                  v-if="
+                                    power.stats.lifetime && power.stats.velocity
+                                  "
+                                  class="italic text-xs mt-1 mr-3 md: mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-range.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Range"
+                                  />
+                                  {{
+                                    power.stats.lifetime *
+                                    parseInt(power.stats.velocity)
+                                  }}
+                                </span>
+                                <span
+                                  v-if="power.stats.restore"
+                                  class="italic text-xs mt-1 mr-3 md: mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-restore.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Restore"
+                                  />
+                                  {{ power.stats.restore }}
+                                  {{ power.stats.restore_type }}
+                                  {{ power.stats.restore_type_time }}
+                                </span>
+                                <span
+                                  v-if="
+                                    power.stats.buff_type_1 &&
+                                      power.stats.buff_amount_1
+                                  "
+                                  class="italic text-xs mt-1 mr-3 md: mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-buff.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Buff"
+                                  />
+                                  {{ power.stats.buff_type_1 }}:
+                                  <span v-if="power.stats.buff_amount_1 > 0">+</span
+                                  >{{ power.stats.buff_amount_1 }}
+                                </span>
+                                <span
+                                  v-if="
+                                    power.stats.buff_type_2 &&
+                                      power.stats.buff_amount_2
+                                  "
+                                  class="italic text-xs mt-1 mr-3 md: mr-5"
+                                >
+                                  <img
+                                    src="/images/ui/power-buff.png"
+                                    class="h-4 inline -mt-1"
+                                    alt="Buff 2"
+                                  />
+                                  {{ power.stats.buff_type_2 }}:
+                                  <span v-if="power.stats.buff_amount_2 > 0">+</span
+                                  >{{ power.stats.buff_amount_2 }}
+                                </span>
+                              </span>
+                              <span
+                              v-if="power.description"
+                              class="block italic text-xs mb-1"
+                            >
+                                {{ power.name }} {{ power.description }}
+                              </span>
+                            </div>
+                            </nuxt-link>
+                          </div>
+                        </div>
+                        <!-- End Power Details -->
+                      </div>
+                    </div>
+                    <div id="prev-powers"
+                         v-if="powerData.chain.prev && powerData.chain.prev.length > 0"
+                         class="w-full ml-4 border-gray-500 border-solid border-l-4 pl-2 mb-2">
+                      <h3 class="text-xs font-medium uppercase text-gray-600 mb-1 tracking-widest">
+                        Previous Power
+                      </h3>
+                      <div v-for="power of powerData.chain.prev">
+                        <!-- Power Details Card TODO: Make this a re-usable component -->
+                        <div id="power-details-prev" class="flex my-2">
+                          <div class="flex-none">
+                            <img
+                              :src="`https://cdn.malekai.org/power/${power.id}.png`"
+                              class="w-10 mr-1"
+                            />
+                          </div>
+
+                          <div class="">
+                            <nuxt-link :to="`/powers/${power.id}`">
+                              <span
+                                class="block text-gray-700 font-medium text-xs uppercase tracking-wide mr-2"
+                              >{{ power.name }}</span
+                              >
+                              <span class="block font-normal text-xs italic">{{
+                                  power.shortDescription
+                                }}</span>
+                              <div class="mt-2 mr-3 align-text-top block clear-both">
+                                <span class="block flex flex-wrap justify-start mb-1 ">
+                                  <span
+                                    v-if="power.stats.cast_time"
+                                    class="italic text-xs mt-1 mr-3 md:mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-casttime.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Cast Time"
+                                    />
+                                    {{ power.stats.cast_time }}
+                                  </span>
+                                  <span
+                                    v-if="power.stats.cooldown"
+                                    class="italic text-xs mt-1 mr-3 md:mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-cooldown.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Cooldown"
+                                    />
+                                    {{ power.stats.cooldown }}
+                                  </span>
+
+                                  <span
+                                    v-if="power.stats.duration"
+                                    class="italic text-xs mt-1 mr-3 md:mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-duration.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Duration"
+                                    />
+                                    {{ power.stats.duration }}
+                                  </span>
+                                  <span
+                                    v-if="power.stats.target"
+                                    class="italic text-xs mt-1 mr-3 md: mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-targetingtype.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Targeting Type"
+                                    />
+                                    {{ power.stats.target }}
+                                  </span>
+                                  <span
+                                    v-if="power.stats.max_targets"
+                                    class="italic text-xs mt-1 mr-3 md:mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-maxtargets.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Max Targets"
+                                    />
+                                    {{ power.stats.max_targets }}
+                                  </span>
+                                  <span
+                                    v-if="power.stats.range"
+                                    class="italic text-xs mt-1 mr-3 md: mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-range.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Range"
+                                    />
+                                    {{ power.stats.range }}
+                                  </span>
+                                  <span
+                                    v-if="
+                                      power.stats.lifetime && power.stats.velocity
+                                    "
+                                    class="italic text-xs mt-1 mr-3 md: mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-range.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Range"
+                                    />
+                                    {{
+                                      power.stats.lifetime *
+                                      parseInt(power.stats.velocity)
+                                    }}
+                                  </span>
+                                  <span
+                                    v-if="power.stats.restore"
+                                    class="italic text-xs mt-1 mr-3 md: mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-restore.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Restore"
+                                    />
+                                    {{ power.stats.restore }}
+                                    {{ power.stats.restore_type }}
+                                    {{ power.stats.restore_type_time }}
+                                  </span>
+                                  <span
+                                    v-if="
+                                      power.stats.buff_type_1 &&
+                                        power.stats.buff_amount_1
+                                    "
+                                    class="italic text-xs mt-1 mr-3 md: mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-buff.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Buff"
+                                    />
+                                    {{ power.stats.buff_type_1 }}:
+                                    <span v-if="power.stats.buff_amount_1 > 0">+</span
+                                    >{{ power.stats.buff_amount_1 }}
+                                  </span>
+                                  <span
+                                    v-if="
+                                      power.stats.buff_type_2 &&
+                                        power.stats.buff_amount_2
+                                    "
+                                    class="italic text-xs mt-1 mr-3 md: mr-5"
+                                  >
+                                    <img
+                                      src="/images/ui/power-buff.png"
+                                      class="h-4 inline -mt-1"
+                                      alt="Buff 2"
+                                    />
+                                    {{ power.stats.buff_type_2 }}:
+                                    <span v-if="power.stats.buff_amount_2 > 0">+</span
+                                    >{{ power.stats.buff_amount_2 }}
+                                  </span>
+                                </span>
+                                <span
+                                  v-if="power.description"
+                                  class="block italic text-xs mb-1"
+                                >
+                                  {{ power.name }} {{ power.description }}
+                                </span>
+                              </div>
+                            </nuxt-link>
+                          </div>
+                        </div>
+                        <!-- End Power Details -->
+                      </div>
+                    </div>
+                  </div>
+                  <!-- End Chained Powers -->
+
                 </div>
               </div>
               <img
@@ -229,9 +576,10 @@ export default {
     MalekaiHeader
   },
   async asyncData({ app, params, error }) {
-    const powerResults = await app.$axios.get(
-      `https://api.malekai.org/powers/${params.id}`
-    )
+    async function getPower(id) {
+      return app.$axios.get(`https://api.malekai.org/powers/${id}`);
+    }
+    const powerResults = await getPower(params.id);
     if (!powerResults)
       error({ statusCode: 404, message: 'powerData: API Error' })
 
@@ -264,11 +612,16 @@ export default {
       },
       stats: powerData.stats,
       chain: {
-        prev: powerData.lastChain,
-        next: powerData.nextChain
+        prev: [],
+        next: []
       },
       tags: powerData.tags
     }
+
+    let nextPowers = await Promise.all(powerData.nextChain.map(id => getPower(id)))
+    let prevPowers = await Promise.all(powerData.lastChain.map(id => getPower(id)))
+    power.chain.next = nextPowers.map(result => result.data.results[0])
+    power.chain.prev = prevPowers.map(result => result.data.results[0])
 
     // used to construct changelog table
     const clRows = []

--- a/pages/powers/index.vue
+++ b/pages/powers/index.vue
@@ -48,10 +48,13 @@
                         </nuxt-link>
                       </td>
                       <td class="p-1 align-text-top">
-                        <span class="block font-medium mb-2">{{
-                          item.name
-                        }}</span>
+                        <nuxt-link :to="`/powers/${item.id}`">
+                        <span class="block font-medium mb-2">
+                            {{ item.name }}
+                        </span>
+
                         <span class="block flex flex-wrap justify-start mb-2">
+
                           <span
                             v-if="item.stats.cast_time"
                             class="italic text-xs mr-3 md:mr-5"
@@ -183,6 +186,7 @@
                         >
                           {{ item.name }} {{ item.description }}
                         </span>
+                        </nuxt-link>
                       </td>
                       <td class="w-0 m-0 p-0"></td>
                       <td class="w-0 m-0 p-0"></td>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/826073/95789289-43b7ec00-0cab-11eb-963d-e78df977b82f.png)

- Powers details page now shows next and previous chained powers for power chains.

- The power details for these chained powers are full detail cards. Similar to my previous change for disciplines where that page now shows full power details. Saves user clicking into each power to view stats

- TODO: Will extract the power details html into a re-usable view. The same code to draw a power's details right now is repeated for 3 sections: previous power, next power and on the disciplines granted powers sections, so 3 times. Component will remove redundancy but wanted to check this simpler way in for now as I have to learn nuxt components.

![image](https://user-images.githubusercontent.com/826073/95789366-6518d800-0cab-11eb-9423-4e03817541a9.png)


